### PR TITLE
Add support of CustomDatatableFieldMapper

### DIFF
--- a/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/HeaderAnnotator.kt
+++ b/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/HeaderAnnotator.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiElement
 
 class HeaderAnnotator: Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        if (!IS_HEADER_CELL.accepts(element)) {
+        if (!IS_HEADER_CELL.accepts(element) || datatableClass(element) == null) {
             return;
         }
         val fields = datatableFields(element)

--- a/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/PsiUtils.kt
+++ b/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/PsiUtils.kt
@@ -1,6 +1,11 @@
 package io.github.deblockt.cucumberdatatabletobeanmappingintelijplugin
 
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.ElementPatternCondition
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
 import org.jetbrains.plugins.cucumber.psi.GherkinElementTypes
 
 val IS_HEADER_CELL = PlatformPatterns.psiElement()


### PR DESCRIPTION
- add support of CustomDatatableFieldMapper
- display error annotation only if datatable is linked with a `@DatatableWithHeader` annotated class