### PR TITLE
fix: error inserting pipe during auto complete

### DIFF
--- a/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/HeaderRowAutocompleteInsertHandler.kt
+++ b/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/HeaderRowAutocompleteInsertHandler.kt
@@ -41,7 +41,7 @@ class HeaderRowAutocompleteInsertHandler: InsertHandler<LookupElement> {
         val headerColumnNumber = table?.headerRow?.psiCells?.size ?: 0;
 
         table?.dataRows
-            ?.filter { it.psiCells.size != headerColumnNumber  }
+            ?.filter { it.psiCells.size < headerColumnNumber  }
             ?.forEachIndexed { index, it ->
                 val endOffset =
                     if (it.psiCells.size < headerCell) {

--- a/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/HeaderRowAutocompleteInsertHandler.kt
+++ b/src/main/kotlin/io/github/deblockt/cucumberdatatabletobeanmappingintelijplugin/HeaderRowAutocompleteInsertHandler.kt
@@ -17,34 +17,40 @@ class HeaderRowAutocompleteInsertHandler: InsertHandler<LookupElement> {
         if (cell != null) {
             val hasTextAfterAutocomplete = cell.text.replace(element.lookupString, "").trim().isNotEmpty()
             val nextSibling = findNextNonSpaceSibling(cell)
-            val table = PsiTreeUtil.getParentOfType(cell, GherkinTable::class.java)
 
             if (nextSibling == null || hasTextAfterAutocomplete) {
                 insertPipe(context.selectionEndOffset, context)
-
-                val headerCell = getHeaderIndex(cell)
-                addColumnOnEachRow(table, headerCell, context)
-
                 PsiDocumentManager.getInstance(context.project).commitDocument(context.editor.document)
             }
+
+            val headerCell = getHeaderIndex(cell)
+            val table = PsiTreeUtil.getParentOfType(cell, GherkinTable::class.java)
+            addMissingColumnOnEachRow(table, headerCell, context)
+
+            PsiDocumentManager.getInstance(context.project).commitDocument(context.editor.document)
+
             table?.replace(CodeStyleManager.getInstance(context.project).reformat(table))
         }
     }
 
-    private fun addColumnOnEachRow(
+    private fun addMissingColumnOnEachRow(
         table: GherkinTable?,
         headerCell: Int,
         context: InsertionContext
     ) {
-        table?.dataRows?.forEach {
-            val endOffset =
-                if (it.psiCells.size < headerCell) {
-                    it.textRange.endOffset
-                } else {
-                    it.psiCells[headerCell - 1].textOffset
-                }
-            insertPipe(endOffset, context)
-        }
+        val headerColumnNumber = table?.headerRow?.psiCells?.size ?: 0;
+
+        table?.dataRows
+            ?.filter { it.psiCells.size != headerColumnNumber  }
+            ?.forEachIndexed { index, it ->
+                val endOffset =
+                    if (it.psiCells.size < headerCell) {
+                        it.textRange.endOffset
+                    } else {
+                        it.psiCells[headerCell - 1].textOffset
+                    }
+                insertPipe(endOffset + index, context)
+            }
     }
 
     private fun insertPipe(offset: Int, context: InsertionContext) {


### PR DESCRIPTION
fix the issue where pipe is badly inserted on autocomplete. 
Before this commit the behavior is like this: 
```
| universe | gm    | category |
| 04       | aaaaa | TYRE|
|          | 114aa | TYRE|
|          | 1142  | TYRE|
```
Adding a a new column give the following datatable
```
| universe | gm    | category | country |
| 04       | aaaaa | TYRE||
|          | 114aa | TYR|E|
|          | 1142  | TY|RE|
```
